### PR TITLE
Replace `np.vectorize`s with `np.frompyfunc`s

### DIFF
--- a/qha/grid_interpolation.py
+++ b/qha/grid_interpolation.py
@@ -11,7 +11,6 @@
 from typing import Optional, Tuple
 
 import numpy as np
-from numpy import vectorize
 
 from qha.fitting import polynomial_least_square_fitting, apply_finite_strain_fitting
 from qha.type_aliases import Vector, Matrix
@@ -26,7 +25,6 @@ __all__ = [
 ]
 
 
-@vectorize
 def calculate_eulerian_strain(v0, vs):
     """
     Calculate the Eulerian strain (:math:`f`s) of a given volume vector *vs* with respect to a reference volume *v0*,
@@ -43,7 +41,6 @@ def calculate_eulerian_strain(v0, vs):
     return 1 / 2 * ((v0 / vs) ** (2 / 3) - 1)
 
 
-@vectorize
 def from_eulerian_strain(v0, fs):
     """
     Calculate the corresponding volumes :math:`V`s from a vector of given Eulerian strains (*fs*)

--- a/qha/multi_configurations/different_phonon_dos.py
+++ b/qha/multi_configurations/different_phonon_dos.py
@@ -124,7 +124,7 @@ class PartitionFunction:
 
         with mpmath.workprec(self.precision):
             # shape = (# of configurations, # of volumes for each configuration)
-            exp = np.vectorize(mpmath.exp)
+            exp = np.frompyfunc(mpmath.exp, 1, 1)
             return exp(-self.aligned_free_energies_for_each_configuration / (K * self.temperature))
 
     @LazyProperty

--- a/qha/statmech.py
+++ b/qha/statmech.py
@@ -7,7 +7,6 @@
 """
 
 import numpy as np
-from numpy import vectorize
 from scipy.constants import physical_constants as pc
 
 import qha.settings
@@ -28,7 +27,6 @@ HBAR = {'ha': 100 / pc['electron volt-inverse meter relationship'][0] / pc['Hart
     qha.settings.energy_unit]
 
 
-@vectorize
 def ho_free_energy(temperature, frequency):
     """
     Calculate Helmholtz free energy of a single harmonic oscillator at a specific temperature.
@@ -50,7 +48,9 @@ def ho_free_energy(temperature, frequency):
         return 1 / 2 * hw + kt * np.log(1 - np.exp(-hw / kt))
 
 
-@vectorize
+ho_free_energy = np.frompyfunc(ho_free_energy, 2, 1)
+
+
 def subsystem_partition_function(temperature, frequency):
     """
     Calculate the subsystem partition function of a single harmonic oscillator at a specific temperature.
@@ -68,7 +68,9 @@ def subsystem_partition_function(temperature, frequency):
     return np.exp(x / 2) / (1 - np.exp(x))
 
 
-@vectorize
+subsystem_partition_function = np.frompyfunc(subsystem_partition_function, 2, 1)
+
+
 def log_subsystem_partition_function(temperature, frequency):
     """
     Calculate the natural logarithm of the subsystem partition function of a single harmonic oscillator
@@ -84,3 +86,6 @@ def log_subsystem_partition_function(temperature, frequency):
 
     x = -HBAR * frequency / (K * temperature)
     return x / 2 - np.log(1 - np.exp(x))
+
+
+log_subsystem_partition_function = np.frompyfunc(log_subsystem_partition_function, 2, 1)

--- a/qha/tools.py
+++ b/qha/tools.py
@@ -10,7 +10,6 @@
 from typing import Callable, Optional
 
 import numpy as np
-from numpy import vectorize
 
 from qha.fitting import polynomial_least_square_fitting
 from qha.grid_interpolation import calculate_eulerian_strain
@@ -38,7 +37,6 @@ def lagrange4(xs: Vector, ys: Vector) -> Callable[[float], float]:
     x0, x1, x2, x3 = xs
     y0, y1, y2, y3 = ys
 
-    @vectorize
     def f(x: float) -> float:
         """
         A helper function that only does the evaluation.
@@ -52,7 +50,7 @@ def lagrange4(xs: Vector, ys: Vector) -> Callable[[float], float]:
                (x - x0) * (x - x1) * (x - x2) / \
             (x3 - x0) / (x3 - x1) / (x3 - x2) * y3
 
-    return f
+    return np.frompyfunc(f, 1, 1)
 
 
 def lagrange3(xs: Vector, ys: Vector) -> Callable[[float], float]:
@@ -83,7 +81,6 @@ def lagrange3(xs: Vector, ys: Vector) -> Callable[[float], float]:
     x0, x1, x2 = xs
     y0, y1, y2 = ys
 
-    @vectorize
     def f(x: float) -> float:
         """
         A helper function that only does the evaluation.
@@ -95,7 +92,7 @@ def lagrange3(xs: Vector, ys: Vector) -> Callable[[float], float]:
                (x - x0) * (x - x2) / (x1 - x0) / (x1 - x2) * y1 + \
                (x - x0) * (x - x1) / (x2 - x0) / (x2 - x1) * y2
 
-    return f
+    return np.frompyfunc(f, 1, 1)
 
 
 def find_nearest(array: Vector, value: Scalar) -> int:


### PR DESCRIPTION
Fix a bug that `vectorize`d functions return zeros when applied to matrices. Do not use `np.vectorize`!